### PR TITLE
Add notion of abstract and optional notifier and update readme accordinly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This project provides a simple way to automatically insert transactions from an
 email notification into [Firefly III](https://www.firefly-iii.org/).
 
 To use it, you'll need a place to run the executable, preferably on a schedule
-with cron or similar; a Firefly III instance; a Mattermost instance (currently
-required for notifications); an email to which you can get IMAP credentials; and
-a bank which will send transaction alerts to that email.
+with cron or similar; a Firefly III instance; a Mattermost instance (optional,
+for receiving notifications); an email to which you can get IMAP credentials;
+and a bank which will send transaction alerts to that email.
 
 The executable will read your recent, unread emails for transactions and then
 check for close matches in your Firefly III instance. If one is not found, it
 will create one based off of the information in the email. Either way, it will
-then notify you via a message in a Mattermost channel and mark the email as
-read.
+then notify you via a message in a Mattermost channel (if configured) and mark
+the email as read.
 
 ## Setup
 
@@ -22,7 +22,7 @@ The basic steps to getting up and running with the Firefly III Email Scanner
 are:
 
 1. Configure Firefly III
-2. Configure a Mattermost bot
+2. Configure a Mattermost bot (optional)
 3. Set up an email account for notifications
 4. Create email notifications
 5. Create an env file (optional)
@@ -39,14 +39,12 @@ get a new one.
 
 For future steps, take note of your Firefly III URL and your PAT.
 
-### Configure a Mattermost bot
+### Configure a Mattermost bot (Optional)
 
-At present, it is required to have a Mattermost instance and bot account set up
-for notifications about actions taken by the email scanner. It would be easy to
-make optional or generic if anyone wants to open a PR.
+You may optionally configure a Mattermost instance and bot account for
+notifications about actions taken by the email scanner.
 
-Then you'll need to set up a Mattermost bot and add it to your channel by
-following
+To set up a Mattermost bot and add it to your channel, follow
 [these directions](https://developers.mattermost.com/integrate/reference/bot-accounts/).
 I created a new channel specifically for these notifications.
 
@@ -108,7 +106,11 @@ process them. The config file format is a work in progress, but the current
 syntax is explained here:
 
 ```yaml
-# The root list, required.
+# Configuration for the mattermost notifier. Optional.
+# You may also set `notifier: stdout` if you would like the notifications
+# printed to stdout for debugging, instead.
+notifier: mattermost
+# The root list of processing steps, required.
 # Each object in the list contains a instructions per bank "from" email
 process_emails:
   # The email that the bank uses to send the emails to you

--- a/common/config.go
+++ b/common/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Config struct {
+	Notifier      *string                 `yaml:"notifier"`
 	ProcessEmails []EmailProcessingConfig `yaml:"process_emails"`
 }
 

--- a/common/notifier.go
+++ b/common/notifier.go
@@ -1,0 +1,8 @@
+package common
+
+// Provides functionality for notifiers to send messages about actions
+// taken by the email scanner.
+type Notifier interface {
+	// Send a message using the notifier. The message will be a markdown string.
+	Notify(markdownMessage string) error
+}

--- a/default_notifiers.go
+++ b/default_notifiers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+)
+
+type StdOutNotifier struct{}
+
+func (s *StdOutNotifier) Notify(message string) error {
+	log.Printf("StdOutNotifier: %s", message)
+	return nil
+}
+
+type NoOpNotifier struct{}
+
+func (n *NoOpNotifier) Notify(message string) error {
+	return nil
+}

--- a/mattermost/mattermost.go
+++ b/mattermost/mattermost.go
@@ -16,8 +16,14 @@ type Post struct {
 	Message   string `json:"message"`
 }
 
+type MattermostNotifier struct{}
+
+// Notify sends a message to Mattermost using the configured channel and token.
+func (mn *MattermostNotifier) Notify(message string) error {
+	return CreateMessage(message)
+}
+
 // Sends a message in Mattermost with the given markdown content.
-//
 // Requires that the MATTERMOST_URL, MATTERMOST_TOKEN, and MATTERMOST_CHANNEL
 // environment variables are set.
 func CreateMessage(message string) error {


### PR DESCRIPTION
Mattermost should no longer be a requirement for setup and a path to future notifiers is created.